### PR TITLE
Clearing tool preview and setting tool to Rectangle Select when pasting

### DIFF
--- a/ts-paint/src/app/services/ts-paint/ts-paint.store.ts
+++ b/ts-paint/src/app/services/ts-paint/ts-paint.store.ts
@@ -119,6 +119,8 @@ export class TsPaintStore extends Store<TsPaintStoreState> {
   pasteFile(pastedFile: File) {
     if (pastedFile !== null) {
       readImageDataFromFile(pastedFile).then((pastedImage) => {
+        this.clearPreview();
+        this.setDrawingTool(DrawingToolType.rectangleSelect);
         const action: PasteImageAction = new PasteImageAction(pastedImage);
         this.executeAction(action);
       });


### PR DESCRIPTION
fixes #8 

The problem was that if the magnifier tool was selected, it wasn't possible to move the pasted image around. Now the issue is avoided because on every paste, the selected tool is changed to Rectangle Select.

Incidentally this works in the same way in the original MS Paint.