### PR TITLE
Fixed positioning of pasted image when zoomed in

### DIFF
--- a/ts-paint/src/app/components/mouse-tracker/mouse-tracker.component.ts
+++ b/ts-paint/src/app/components/mouse-tracker/mouse-tracker.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, Input, OnChanges, Output, EventEmit
 import { Point } from '../../types/base/point';
 import { TspMouseEvent } from 'src/app/types/mouse-tracker/tsp-mouse-event';
 import { MouseButton } from 'src/app/types/mouse-tracker/mouse-button';
-import { constrainPointToImage } from 'src/app/helpers/image.helpers';
+import { constrainPointToImage, unzoomPoint } from 'src/app/helpers/image.helpers';
 
 @Component({
   selector: 'tsp-mouse-tracker',
@@ -90,11 +90,7 @@ export class MouseTrackerComponent implements OnChanges {
 
   private getEventPoint(event: MouseEvent | WheelEvent): Point {
     // @ts-ignore
-    const eventPoint: Point = this.unzoomPoint({ w: event.layerX, h: event.layerY });
+    const eventPoint: Point = unzoomPoint({ w: event.layerX, h: event.layerY }, this.zoom);
     return constrainPointToImage(this.image, eventPoint);
-  }
-
-  private unzoomPoint(zoomedPoint: Point): Point {
-    return { w: Math.floor(zoomedPoint.w / this.zoom), h: Math.floor(zoomedPoint.h / this.zoom) };
   }
 }

--- a/ts-paint/src/app/helpers/image.helpers.ts
+++ b/ts-paint/src/app/helpers/image.helpers.ts
@@ -166,3 +166,7 @@ export function constrainPointToImage(image: ImageData, point: Point): Point {
   const h: number = Math.min(Math.max(0, point.h), (image?.height ?? 1) - 1);
   return { w, h };
 }
+
+export function unzoomPoint(zoomedPoint: Point, zoom: number): Point {
+  return { w: Math.floor(zoomedPoint.w / zoom), h: Math.floor(zoomedPoint.h / zoom) };
+}

--- a/ts-paint/src/app/services/ts-paint/ts-paint.store.ts
+++ b/ts-paint/src/app/services/ts-paint/ts-paint.store.ts
@@ -14,7 +14,7 @@ import { OpenFileAction } from '../../types/actions/open-file-action';
 import { ClearImageAction } from '../../types/actions/clear-image-action';
 import { PasteImageAction } from '../../types/actions/paste-image-action';
 import { RectangleArea } from '../../types/base/rectangle-area';
-import { isPointInRectangle, copyImagePart } from '../../helpers/image.helpers';
+import { isPointInRectangle, copyImagePart, unzoomPoint } from '../../helpers/image.helpers';
 import { DeselectSelectionAction } from '../../types/actions/deselect-selection-action';
 import { MoveSelectionTool } from '../../types/drawing-tools/move-selection-tool';
 import {
@@ -121,7 +121,10 @@ export class TsPaintStore extends Store<TsPaintStoreState> {
       readImageDataFromFile(pastedFile).then((pastedImage) => {
         this.clearPreview();
         this.setDrawingTool(DrawingToolType.rectangleSelect);
-        const action: PasteImageAction = new PasteImageAction(pastedImage);
+        const action: PasteImageAction = new PasteImageAction(
+          pastedImage,
+          unzoomPoint(this.state.scrollPosition, this.state.zoom)
+        );
         this.executeAction(action);
       });
     }

--- a/ts-paint/src/app/types/actions/paste-image-undo-action.ts
+++ b/ts-paint/src/app/types/actions/paste-image-undo-action.ts
@@ -2,17 +2,19 @@ import { TsPaintAction } from './ts-paint-action';
 import { TsPaintStoreState } from '../../services/ts-paint/ts-paint.store.state';
 import { PartialActionResult } from './partial-action-result';
 import { resizeImage } from '../../helpers/image.helpers';
+import { Point } from '../base/point';
 
-/** This action exists only  to avoid a circular dependency in DeleteSelectionAction */
+/** This action exists only to avoid a circular dependency arising from the use of PasteImageAction as
+ * an undo action in DeleteSelectionAction. In all other places, PasteImageAction should be used. */
 export class PasteImageUndoAction extends TsPaintAction {
-  constructor(private _imagePart: ImageData) {
+  constructor(private _imagePart: ImageData, private _position: Point = { w: 0, h: 0 }) {
     super('image');
     this._deselectsSelection = true;
   }
 
   protected addPatchesAndDraw(state: TsPaintStoreState): PartialActionResult {
     const patches: Partial<TsPaintStoreState> = {};
-    patches.selectionOffset = { w: 0, h: 0 };
+    patches.selectionOffset = this._position;
     patches.selectionImage = this._imagePart;
     patches.moveSelectionTool = undefined; // It will get initialized if needed
 


### PR DESCRIPTION
fixes #10 

When pasting image data, it always gets positioned to coordinates (0,0). If magnification is active and (0,0) is not in the viewport, the pasted image should be placed where the viewport is.